### PR TITLE
Use next_release method as next was deprecated

### DIFF
--- a/lib/App/PAUSE/CheckPerms.pm
+++ b/lib/App/PAUSE/CheckPerms.pm
@@ -24,7 +24,7 @@ sub execute
     my $bad_count = 0;
 
     RELEASE:
-    while (my $release = $release_iterator->next) {
+    while (my $release = $release_iterator->next_release) {
         if ($self->user) {
             my $seen_user = 0;
             my $USER      = uc($self->user);


### PR DESCRIPTION
This prevents the application crashing with an up to date version of PAUSE::Packages.

```
Can't locate object method "next" via package "PAUSE::Packages::ReleaseIterator" at /home/colin/perl5/perlbrew/perls/perl-5.20.3/lib/site_perl/5.20.3/App/PAUSE/CheckPerms.pm line 27.
 at /home/colin/perl5/perlbrew/perls/perl-5.20.3/lib/site_perl/5.20.3/App/PAUSE/CheckPerms.pm line 27.

```
